### PR TITLE
Common sense refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The exporter will scan the system for available devices if no ```--smartctl.devi
 
 - `smartctl_exp_port`: "0.0.0.0:9633"  # Addresses on which to expose metrics and web interface. Repeatable for multiple addresses.
 - `smartctl_exp_version`: "0.14.0" # exporter version to install
-smartctl_exp_dir: "/etc/exporters" # where to download and unarchive expoter 
 - `smartctl_exp_config_dir`:  "/etc/exporters/config" # Path to configuration file that can enable TLS or authentication
 - `smartctl_exp_interval`: "60s" # The interval between smartctl polls
 - `smartctl_exp_rescan`: "10m" # The interval between rescanning for new/disappeared devices. If the interval is smaller than 1s no rescanning takes place. If any devices are configured with smartctl.device also no rescanning takes place.
@@ -44,7 +43,6 @@ Example Playbook
 roles:
 - role: genlab.smartctl_exporter
     smartctl_exp_version: "0.14.0"
-    smartctl_exp_dir: "/etc/exporters"
     smartctl_exp_config_dir: "/etc/exporters/config"
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,29 +6,32 @@ genlab.smartctl-exporter
 Requirements
 ------------
 
-smartctl 
+```smartmontools``` >= 7.0, because export to json released in 7.0
 
 Role Variables
 --------------
-The exporter will scan the system for available devices if no ```--smartctl.device``` flags are used. The format of web.config file id described [here](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md). If ```smartctl_exp_source_web_config_dir``` is defined, role searches for ```web_smartctl.conf``` file and copy it to target host to ```smartctl_exp_web_config_dir``` directory
-```yaml
----
-smartctl_exp_port: "localhost:9633"  # Addresses on which to expose metrics and web interface. Repeatable for multiple addresses.
-smartctl_exp_version: "0.14.0" # exporter version to install
-smartctl_exp_dir: "/etc/exporters" # where to download and unarchive expoter 
-smartctl_exp_web_config_dir:  "/etc/exporters/config" # Path to configuration file that can enable TLS or authentication
-smartctl_exp_interval: "60s" # The interval between smartctl polls
-smartctl_exp_rescan: "10m" # The interval between rescanning for new/disappeared devices. If the interval is smaller than 1s no rescanning takes place. If any devices are configured with smartctl.device also no rescanning takes place.
-smartctl_exp_devices: [] # The device to monitor (repeatable)
-smartctl_exp_device_exclude: "" #Regexp of devices to exclude from automatic scanning. (mutually exclusive to device-include)
-smartctl_exp_device_include: "" #  Regexp of devices to include in automatic scanning. (mutually exclusive to device-exclude)
-smartctl_exp_web_telemetry_path: "/metrics" # Path under which to expose metrics
-smartctl_exp_log_level: "info" # Only log messages with the given severity or above. One of: [debug, info, warn, error]
-smartctl_exp_log_format: "logfmt" # Output format of log messages. One of: [logfmt, json]
-smartctl_exp_args: # --version --web.systemd-socket 
 
-smartctl_exp_source_web_config_dir: ""
-```
+The exporter will scan the system for available devices if no ```--smartctl.device``` flags are used. The format of the web.config file is described [here](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md). If ```smartctl_exp_web_conf_path``` is defined, the role searches for the ```web_smartctl.conf``` file and copies it to the target host's smartctl_exp_config_dir directory.
+
+- `smartctl_exp_port`: "0.0.0.0:9633"  # Addresses on which to expose metrics and web interface. Repeatable for multiple addresses.
+- `smartctl_exp_version`: "0.14.0" # exporter version to install
+smartctl_exp_dir: "/etc/exporters" # where to download and unarchive expoter 
+- `smartctl_exp_config_dir`:  "/etc/exporters/config" # Path to configuration file that can enable TLS or authentication
+- `smartctl_exp_interval`: "60s" # The interval between smartctl polls
+- `smartctl_exp_rescan`: "10m" # The interval between rescanning for new/disappeared devices. If the interval is smaller than 1s no rescanning takes place. If any devices are configured with smartctl.device also no rescanning takes place.
+- `smartctl_exp_devices`: [] # The device to monitor (repeatable)
+- `smartctl_exp_device_exclude`: "" #Regexp of devices to exclude from automatic scanning. (mutually exclusive to device-include)
+- `smartctl_exp_device_include`: "" #  Regexp of devices to include in automatic scanning. (mutually exclusive to device-exclude)
+-`smartctl_exp_web_telemetry_path`: "/metrics" # Path under which to expose metrics
+- `smartctl_exp_log_level`: "info" # Only log messages with the given severity or above. One of: [debug, info, warn, error]
+- `smartctl_exp_log_format`: "logfmt" # Output format of log messages. One of: [logfmt, json]
+- `smartctl_exp_args`: 
+    - `--version`: Show application version.
+    - `--web.systemd-socket`: Use systemd socket activation listeners instead of port listeners (Linux only).
+
+
+- `smartctl_exp_web_conf_path`: ""
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements
 Role Variables
 --------------
 
-The exporter will scan the system for available devices if no ```--smartctl.device``` flags are used. The format of the web.config file is described [here](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md). If ```smartctl_exp_web_conf_path``` is defined, the role searches for the ```web_smartctl.conf``` file and copies it to the target host's smartctl_exp_config_dir directory.
+The exporter will scan the system for available devices if no ```--smartctl.device``` flags are used. The format of the web.config file is described [here](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md). If ```smartctl_exp_web_conf_path``` is defined, the role searches for the ```web_smartctl.conf``` file and copies it to the target host's ```smartctl_exp_config_dir``` directory.
 
 - `smartctl_exp_port`: "0.0.0.0:9633"  # Addresses on which to expose metrics and web interface. Repeatable for multiple addresses.
 - `smartctl_exp_version`: "0.14.0" # exporter version to install

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-smartctl_exp_web_listen_address: "localhost:9633"
+smartctl_exp_web_listen_address: "0.0.0.0:9633"
 smartctl_exp_args: ""
 smartctl_exp_version: "0.14.0"
 smartctl_exp_dir: "/etc/exporters"
-smartctl_exp_web_config_dir: "/etc/exporters/config"
+smartctl_exp_config_dir: "/etc/exporters/config"
 smartctl_exp_interval: "60s"
 smartctl_exp_rescan: "10m"
 smartctl_exp_devices: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,7 @@
 smartctl_exp_web_listen_address: "0.0.0.0:9633"
 smartctl_exp_args: ""
 smartctl_exp_version: "0.14.0"
-smartctl_exp_dir: "/etc/exporters"
-smartctl_exp_config_dir: "/etc/exporters/config"
+smartctl_exp_config_dir: "/etc/smartctl_exp"
 smartctl_exp_interval: "60s"
 smartctl_exp_rescan: "10m"
 smartctl_exp_devices: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: "smartctl_exporter"
   namespace: genlab
-  author: "Alexander Gorelyshev"
+  author: "Mary Sayganova"
   company: "Genlab, LLC"
   description: ""
   license: "MIT"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,5 +3,4 @@
   hosts: all
   roles:
     - role: genlab.smartctl_exporter
-      smartctl_exp_dir: "/etc/exporters"
       smartctl_exp_config_dir: "/etc/exporters/config"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,10 +1,18 @@
 ---
+- name: "Create smartctl_exporter configuration directory"
+  ansible.builtin.file:
+    path: "{{ smartctl_exp_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: "Upload smartctl_exporter local configure file"
   notify: "(Re)start and enable smartctl_exporter"
   when: smartctl_exp_source_web_config_dir is defined and smartctl_exp_source_web_config_dir | length > 0
   ansible.builtin.template:
-    src: "{{ smartctl_exp_source_web_config_dir }}/web_smartctl.conf"
-    dest: "{{ smartctl_exp_web_config_dir }}/web_smartctl.conf"
+    src: "{{ smartctl_exp_web_con_path }}"
+    dest: "{{ smartctl_exp_config_dir }}/web_smartctl.conf"
     owner: root
     group: root
     mode: '0640'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -11,7 +11,7 @@
   notify: "(Re)start and enable smartctl_exporter"
   when: smartctl_exp_source_web_config_dir is defined and smartctl_exp_source_web_config_dir | length > 0
   ansible.builtin.template:
-    src: "{{ smartctl_exp_web_con_path }}"
+    src: "{{ smartctl_exp_web_conf_path }}"
     dest: "{{ smartctl_exp_config_dir }}/web_smartctl.conf"
     owner: root
     group: root

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,28 +14,17 @@
         fail_msg: "smartctl_exporter version {{ smartctl_exp_version }} is not installed or not working correctly"
 
   rescue:
-    - name: "Create smartctl_exporter directories"
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        owner: root
-        group: root
-        mode: "0755"
-      with_items:
-        - "{{ smartctl_exp_dir }}"
-        - "{{ smartctl_exp_config_dir }}"
-
     - name: "Unarchive smartctl_exporter tar file"
       notify: "(Re)start and enable smartctl_exporter"
       ansible.builtin.unarchive:
         src: "https://github.com/prometheus-community/smartctl_exporter/releases/\
               download/v{{ smartctl_exp_version }}/smartctl_exporter-{{ smartctl_exp_version }}.linux-amd64.tar.gz"
-        dest: "{{ smartctl_exp_dir }}"
+        dest: "/tmp"
         remote_src: true
 
     - name: "Move smartctl_exporter binary"
       ansible.builtin.copy:
-        src: "{{ smartctl_exp_dir }}/smartctl_exporter-{{ smartctl_exp_version }}.linux-amd64/smartctl_exporter"
+        src: "/tmp/smartctl_exporter-{{ smartctl_exp_version }}.linux-amd64/smartctl_exporter"
         dest: "/usr/local/bin/smartctl_exporter"
         mode: "0755"
         owner: root

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,6 +43,7 @@
         remote_src: true
 
 - name: Create systemd service file
+  notify: "(Re)start and enable smartctl_exporter"
   ansible.builtin.template:
     src: smartctl_exporter.service.j2
     dest: /etc/systemd/system/smartctl_exporter.service

--- a/templates/smartctl_exporter.service.j2
+++ b/templates/smartctl_exporter.service.j2
@@ -26,8 +26,8 @@ ExecStart=/usr/local/bin/smartctl_exporter \
 {% if smartctl_exp_args is defined and smartctl_exp_args | length > 0 %}
       {{ smartctl_exp_args }} \
 {% endif %}
-{% if smartctl_exp_source_web_config_dir is defined and smartctl_exp_source_web_config_dir | length > 0 %} \
-    --web.config.file={{ smartctl_exp_web_config_dir }}/web_smartctl.conf
+{% if smartctl_exp_web_conf_path is defined and smartctl_exp_web_conf_path | length > 0 %} \
+    --web.config.file={{ smartctl_exp_config_dir }}/web_smartctl.conf
 {% endif %}
 
 SyslogIdentifier=smartctl_exporter


### PR DESCRIPTION
- Push configuration files directly into a clearly called folder
- Download to /tmp instead of /etc